### PR TITLE
Attachment preview

### DIFF
--- a/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
+++ b/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
@@ -109,11 +109,10 @@ public class MainFragment extends Fragment {
     @Override
     public void onSend(final Editable data, List<? extends Attachment> attachments) {
       msgAdapter.addMessage(data);
-      msgAdapter.addMessage(Editable.Factory.getInstance().newEditable(
-          String.format("%d Attachments found", attachments.size())));
-      for (Attachment a : attachments) {
+
+      for (int i = 0; i < attachments.size(); i++) {
         msgAdapter.addMessage(Editable.Factory.getInstance().newEditable(
-            "> Attachment - " + a.displayName));
+            String.format("[%d] Attachment - %s", i, attachments.get(i).displayName)));
       }
     }
   };

--- a/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
+++ b/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
@@ -19,6 +19,7 @@ import com.lytefast.flexinput.FlexInput;
 import com.lytefast.flexinput.InputListener;
 import com.lytefast.flexinput.KeyboardManager;
 import com.lytefast.flexinput.SimpleFileManager;
+import com.lytefast.flexinput.adapters.AttachmentPreviewAdapter;
 import com.lytefast.flexinput.emoji.Emoji;
 import com.lytefast.flexinput.fragment.EmojiCategoryPagerFragment;
 import com.lytefast.flexinput.model.Attachment;
@@ -71,6 +72,8 @@ public class MainFragment extends Fragment {
     final InputMethodManager imm =
         (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 
+    recyclerView.setAdapter(msgAdapter);
+
     if (savedInstanceState == null) {
       // Only create fragment on first load
       flexInput.setEmojiFragment(getChildFragmentManager(), new UnicodeEmojiCategoryPagerFragment());
@@ -78,6 +81,8 @@ public class MainFragment extends Fragment {
 
     flexInput
         .initContentPages(getFragmentManager())
+        // Can be extended to provide custom previews (e.g. larger preview images, onclick) etc.
+        .setAttachmentPreviewAdapter(new AttachmentPreviewAdapter(getContext().getContentResolver()))
         .setInputListener(flexInputListener)
         .setFileManager(new SimpleFileManager("com.lytefast.flexinput.fileprovider", "FlexInput"))
         .setKeyboardManager(new KeyboardManager() {
@@ -92,8 +97,6 @@ public class MainFragment extends Fragment {
             imm.hideSoftInputFromWindow(flexInput.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
           }
         });
-
-    recyclerView.setAdapter(msgAdapter);
   }
 
   @Override
@@ -106,8 +109,11 @@ public class MainFragment extends Fragment {
     @Override
     public void onSend(final Editable data, List<? extends Attachment> attachments) {
       msgAdapter.addMessage(data);
+      msgAdapter.addMessage(Editable.Factory.getInstance().newEditable(
+          String.format("%d Attachments found", attachments.size())));
       for (Attachment a : attachments) {
-        msgAdapter.addMessage(Editable.Factory.getInstance().newEditable("Attachment - " + a.displayName));
+        msgAdapter.addMessage(Editable.Factory.getInstance().newEditable(
+            "> Attachment - " + a.displayName));
       }
     }
   };

--- a/app/src/main/res/layout/fragment_message_main.xml
+++ b/app/src/main/res/layout/fragment_message_main.xml
@@ -36,6 +36,7 @@
         android:focusable="true"
         android:focusableInTouchMode="true"
         app:inputBackground="@drawable/rect_rounded_highlight_alpha_20"
+        app:previewBackground="@drawable/rect_rounded_highlight_alpha_20"
         app:tabsBackground="@drawable/content_tab_background"
         app:hint="@string/msg_hint"
         app:hintColor="@color/colorHint"

--- a/flexinput/src/main/java/com/lytefast/flexinput/FlexInput.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/FlexInput.java
@@ -23,7 +23,6 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.RelativeLayout;
-import android.widget.Toast;
 
 import com.lytefast.flexinput.adapters.AttachmentPreviewAdapter;
 import com.lytefast.flexinput.emoji.Emoji;
@@ -40,8 +39,6 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -59,9 +56,11 @@ public class FlexInput extends RelativeLayout {
   public static final int TAB_FILES = 0;
   public static final int TAB_CAMERA = 2;
 
+  @BindView(R2.id.attachment_preview_container) View attachmentPreviewContainer;
   @BindView(R2.id.main_input_container) View inputContainer;
   @BindView(R2.id.add_content_container) View addContentContainer;
   @BindView(R2.id.emoji_container) View emojiContainer;
+
   @BindView(R2.id.attachment_preview_list) RecyclerView attachmentPreviewList;
 
   @BindView(R2.id.text_input) AppCompatEditText textEt;
@@ -129,7 +128,7 @@ public class FlexInput extends RelativeLayout {
       if (a.hasValue(R.styleable.FlexInput_previewBackground)) {
         Drawable backgroundDrawable = a.getDrawable(R.styleable.FlexInput_previewBackground);
         backgroundDrawable.setCallback(this);
-        attachmentPreviewList.setBackground(backgroundDrawable);
+        attachmentPreviewContainer.setBackground(backgroundDrawable);
       }
 
       if (a.hasValue(R.styleable.FlexInput_tabsBackground)) {
@@ -160,9 +159,6 @@ public class FlexInput extends RelativeLayout {
    *
    * Note that this should only be set once for the life of the containing fragment. Make sure to
    * check the <code>savedInstanceState</code> before creating and saving another fragment.
-   *
-   * @param childFragmentManager
-   * @param emojiFragment
    *
    * @return
    */
@@ -296,17 +292,22 @@ public class FlexInput extends RelativeLayout {
       return;  // Nothing to do here
     }
 
+    inputListener.onSend(textEt.getText(), attachmentPreviewAdapter.getAttachments());
+    textEt.setText("");
+    clearAttachments();
+  }
+
+  @OnClick(R2.id.attachment_clear_btn)
+  void clearAttachments() {
     if (photosFragment != null) {
       photosFragment.clearSelectedAttachments();
     }
 
-    if (filesFragment != null ){
+    if (filesFragment != null) {
       filesFragment.clearSelectedAttachments();
     }
-
-    inputListener.onSend(textEt.getText(), attachmentPreviewAdapter.getAttachments());
-    textEt.setText("");
     attachmentPreviewAdapter.clear();
+    attachmentPreviewContainer.setVisibility(GONE);
   }
 
   @OnTouch(R2.id.text_input)
@@ -409,6 +410,8 @@ public class FlexInput extends RelativeLayout {
 
   public void handleAttachmentClick(ItemClickedEvent<Attachment> event) {
     attachmentPreviewAdapter.toggleItem(event.item);
+    attachmentPreviewContainer.setVisibility(
+        attachmentPreviewAdapter.getItemCount() == 0 ? GONE : VISIBLE);
   }
 
   //endregion

--- a/flexinput/src/main/java/com/lytefast/flexinput/FlexInput.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/FlexInput.java
@@ -1,5 +1,6 @@
 package com.lytefast.flexinput;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
@@ -93,6 +94,7 @@ public class FlexInput extends RelativeLayout {
     init(attrs, defStyle);
   }
 
+  //region Initialization Methods
   private void init(AttributeSet attrs, int defStyle) {
     inflate(getContext(), R.layout.fancy_input_wrapper, this);
     ButterKnife.bind(this);
@@ -101,13 +103,6 @@ public class FlexInput extends RelativeLayout {
     setFocusableInTouchMode(true);
 
     initAttributes(attrs, defStyle);
-
-    initAttachmentPreview();
-  }
-
-  private void initAttachmentPreview() {
-    attachmentPreviewAdapter = new AttachmentPreviewAdapter(getContext().getContentResolver());
-    attachmentPreviewList.setAdapter(attachmentPreviewAdapter);
   }
 
   private void initAttributes(final AttributeSet attrs, final int defStyle) {
@@ -146,6 +141,7 @@ public class FlexInput extends RelativeLayout {
       a.recycle();
     }
   }
+  //endregion
 
   @Override
   protected void onAttachedToWindow() {
@@ -182,6 +178,22 @@ public class FlexInput extends RelativeLayout {
 
   public FlexInput setInputListener(@NonNull final InputListener inputListener) {
     this.inputListener = inputListener;
+    return this;
+  }
+
+  /**
+   * Set an {@link android.support.v7.widget.RecyclerView.Adapter} implementation that knows how render {@link Attachment}s.
+   * If this is not set, no attachment preview will be shown.
+   *
+   * @param previewAdapter An adapter that knows how to display {@link Attachment}s
+   *
+   * @return the current instance of {@link FlexInput} for chaining commands
+   *
+   * @see AttachmentPreviewAdapter#AttachmentPreviewAdapter(ContentResolver) for a default implementation of attachment previews
+   */
+  public FlexInput setAttachmentPreviewAdapter(@NonNull final AttachmentPreviewAdapter previewAdapter) {
+    this.attachmentPreviewAdapter = previewAdapter;
+    this.attachmentPreviewList.setAdapter(attachmentPreviewAdapter);
     return this;
   }
 
@@ -284,8 +296,6 @@ public class FlexInput extends RelativeLayout {
       return;  // Nothing to do here
     }
 
-    // TODO move selection into it's own managed class so we can keep order
-    final List<Attachment> attachments = new ArrayList<>(4);
     if (photosFragment != null) {
       photosFragment.clearSelectedAttachments();
     }

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/AttachmentPreviewAdapter.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/AttachmentPreviewAdapter.java
@@ -1,0 +1,95 @@
+package com.lytefast.flexinput.adapters;
+
+import android.content.ContentResolver;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.drawee.view.SimpleDraweeView;
+import com.lytefast.flexinput.R;
+import com.lytefast.flexinput.model.Attachment;
+import com.lytefast.flexinput.model.Photo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * {@link RecyclerView.Adapter} which, given a list of attachments understands how to display them.
+ * This can be extended to implement custom previews.
+ *
+ * @author Sam Shih
+ */
+public class AttachmentPreviewAdapter extends RecyclerView.Adapter<AttachmentPreviewAdapter.ViewHolder> {
+
+  private final ContentResolver contentesolver;
+
+  protected final List<Attachment> attachments;
+
+
+  public AttachmentPreviewAdapter(final ContentResolver contentesolver) {
+    this.contentesolver = contentesolver;
+    this.attachments = new ArrayList<>();
+  }
+
+  @Override
+  public ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
+    View view = LayoutInflater.from(parent.getContext())
+        .inflate(R.layout.view_attachment_preview_item, parent, false);
+    return new ViewHolder(view);
+  }
+
+  @Override
+  public void onBindViewHolder(final ViewHolder holder, final int position) {
+    Attachment item = attachments.get(position);
+    holder.bind(item);
+  }
+
+  @Override
+  public int getItemCount() {
+    return attachments.size();
+  }
+
+  public List<Attachment> getAttachments() {
+    return attachments;
+  }
+
+  public void clear() {
+    attachments.clear();
+    notifyDataSetChanged();
+  }
+
+  public boolean toggleItem(Attachment item) {
+    final int oldIndex = attachments.indexOf(item);
+    final boolean wasRemoved = attachments.remove(item);
+
+    if (wasRemoved) {
+      notifyItemRemoved(oldIndex);
+    } else {
+      attachments.add(item);
+      notifyItemInserted(attachments.size() - 1);
+    }
+    return wasRemoved;
+  }
+
+  class ViewHolder extends RecyclerView.ViewHolder {
+
+    private final SimpleDraweeView draweeView;
+
+    public ViewHolder(final View itemView) {
+      super(itemView);
+      this.draweeView = (SimpleDraweeView) itemView;
+    }
+
+    public void bind(Attachment item) {
+      if (item instanceof Photo) {
+        draweeView.setImageURI(((Photo) item).getThumbnailUri(contentesolver));
+      } else if (item.uri != null) {
+        draweeView.setImageURI(item.uri);
+      } else {
+        draweeView.setImageResource(R.drawable.ic_attach_file_24dp);
+      }
+    }
+  }
+}

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
@@ -15,7 +15,10 @@ import android.widget.Toast;
 import com.lytefast.flexinput.R;
 import com.lytefast.flexinput.adapters.OnItemClickListener;
 import com.lytefast.flexinput.adapters.PhotoCursorAdapter;
+import com.lytefast.flexinput.events.ItemClickedEvent;
 import com.lytefast.flexinput.model.Photo;
+
+import org.greenrobot.eventbus.EventBus;
 
 import java.util.Collection;
 
@@ -76,6 +79,7 @@ public class PhotosFragment extends Fragment implements AttachmentSelector<Photo
         public void onItemClicked(final Photo item) {
           Toast.makeText(getContext(),
               "Toggle[" + item.id + "]: " + item.displayName, Toast.LENGTH_SHORT).show();
+          EventBus.getDefault().post(new ItemClickedEvent<>(item));
         }
       });
     }

--- a/flexinput/src/main/res/drawable/ic_clear_24dp.xml
+++ b/flexinput/src/main/res/drawable/ic_clear_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/flexinput/src/main/res/layout/fancy_input_wrapper.xml
+++ b/flexinput/src/main/res/layout/fancy_input_wrapper.xml
@@ -1,25 +1,47 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/attachment_preview_list"
+    <LinearLayout
+        android:id="@+id/attachment_preview_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/input_container_margin"
-        android:layout_marginRight="@dimen/input_container_margin"
+        android:layout_margin="@dimen/input_container_margin"
+        android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:layout_alignParentTop="true"
-        app:layoutManager="LinearLayoutManager"
-        tools:listitem="@layout/view_attachment_preview_item"/>
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/attachment_preview_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/input_container_margin"
+            android:layout_marginRight="@dimen/input_container_margin"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            app:layoutManager="LinearLayoutManager"
+            tools:context="com.lytefast.flexinput.fragment.AttachmentPreviewAdapter"
+            tools:listitem="@layout/view_attachment_preview_item"/>
+
+        <android.support.v7.widget.AppCompatImageButton
+            android:id="@+id/attachment_clear_btn"
+            style="@style/Input.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@id/attachment_preview_list"
+            android:layout_alignParentRight="true"
+            android:contentDescription="Clear attachments"
+            android:src="@drawable/ic_clear_24dp"/>
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/main_input_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/input_height"
-        android:layout_below="@id/attachment_preview_list"
         android:orientation="horizontal"
         android:layout_margin="@dimen/input_container_margin"
         android:gravity="center_vertical">
@@ -67,7 +89,6 @@
         android:id="@+id/add_content_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/default_keyboard_height"
-        android:layout_below="@id/main_input_container"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -118,10 +139,9 @@
         android:id="@+id/emoji_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/default_keyboard_height"
-        android:layout_below="@id/main_input_container"
         android:orientation="vertical"
         android:visibility="gone"
         tools:background="#6b7ba1"
         tools:visibility="gone" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/flexinput/src/main/res/layout/fancy_input_wrapper.xml
+++ b/flexinput/src/main/res/layout/fancy_input_wrapper.xml
@@ -4,12 +4,24 @@
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/attachment_preview_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/input_container_margin"
+        android:layout_marginRight="@dimen/input_container_margin"
+        android:orientation="horizontal"
+        android:layout_alignParentTop="true"
+        app:layoutManager="LinearLayoutManager"
+        tools:listitem="@layout/view_attachment_preview_item"/>
+
     <LinearLayout
         android:id="@+id/main_input_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/input_height"
+        android:layout_below="@id/attachment_preview_list"
         android:orientation="horizontal"
-        android:layout_margin="4dp"
+        android:layout_margin="@dimen/input_container_margin"
         android:gravity="center_vertical">
 
         <android.support.v7.widget.AppCompatImageButton

--- a/flexinput/src/main/res/layout/view_attachment_preview_item.xml
+++ b/flexinput/src/main/res/layout/view_attachment_preview_item.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.drawee.view.SimpleDraweeView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="@dimen/attachment_preview_dimen"
+    android:layout_height="@dimen/attachment_preview_dimen"
+
+    android:layout_margin="@dimen/grid_item_padding"
+    android:adjustViewBounds="true"
+
+    android:scaleType="fitCenter"
+    app:actualImageScaleType="focusCrop"
+    app:fadeDuration="@android:integer/config_shortAnimTime"
+    app:placeholderImage="@drawable/ic_file_24dp"
+    app:placeholderImageScaleType="focusCrop"
+    app:viewAspectRatio="1.0"
+    tools:src="@drawable/ic_file_24dp" />

--- a/flexinput/src/main/res/values/attrs_fancy_input.xml
+++ b/flexinput/src/main/res/values/attrs_fancy_input.xml
@@ -5,5 +5,6 @@
         <attr name="hintColor" format="color"/>
         <attr name="inputBackground" format="color|reference"/>
         <attr name="tabsBackground" format="color|reference"/>
+        <attr name="previewBackground" format="color|reference"/>
     </declare-styleable>
 </resources>

--- a/flexinput/src/main/res/values/dimens.xml
+++ b/flexinput/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
     <dimen name="default_keyboard_height">280dp</dimen>
     <dimen name="grid_item_padding">2dp</dimen>
     <dimen name="file_icon_dimen">64dp</dimen>
+    <dimen name="attachment_preview_dimen">32dp</dimen>
 
     <dimen name="emoji_text_size">32dp</dimen>
     <dimen name="emoji_grid_item_size">48dp</dimen>

--- a/flexinput/src/main/res/values/dimens.xml
+++ b/flexinput/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="text_margin">16dp</dimen>
+    <dimen name="input_container_margin">4dp</dimen>
 
     <dimen name="input_height">48dp</dimen>
     <dimen name="default_keyboard_height">280dp</dimen>


### PR DESCRIPTION
Add an attachment preview layout above input that displays currently selected items.

Selections now work after screen rotations

![image](https://cloud.githubusercontent.com/assets/5618601/21946210/37120fce-d994-11e6-8cd3-baba7a45db5c.png)