### PR TITLE
Allow user defined eventbus

### DIFF
--- a/flexinput-eventbus/src/main/java/com/lytefast/flexinput/eventbus/EventBusManager.java
+++ b/flexinput-eventbus/src/main/java/com/lytefast/flexinput/eventbus/EventBusManager.java
@@ -25,7 +25,7 @@ public class EventBusManager implements EventManager {
   }
 
   @Override
-  public void postOnItemClicked(final Attachment item) {
+  public <T> void postOnItemClicked(final T item) {
     EventBus.getDefault().post(new ItemClickedEvent<>(item));
   }
 

--- a/flexinput-rxjava/src/main/java/com/lytefast/flexinput/rxjava/EventRxJavaManager.java
+++ b/flexinput-rxjava/src/main/java/com/lytefast/flexinput/rxjava/EventRxJavaManager.java
@@ -44,7 +44,7 @@ public class EventRxJavaManager implements EventManager {
   }
 
   @Override
-  public void postOnItemClicked(final Attachment item) {
+  public <T> void postOnItemClicked(final T item) {
     getOrCreate(ItemClickedEvent.class)
         .onNext(new ItemClickedEvent(item));
   }

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/EmojiGridFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/EmojiGridFragment.java
@@ -13,12 +13,10 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.lytefast.flexinput.FlexInput;
 import com.lytefast.flexinput.R;
 import com.lytefast.flexinput.R2;
 import com.lytefast.flexinput.model.Emoji;
-import com.lytefast.flexinput.events.ItemClickedEvent;
-
-import org.greenrobot.eventbus.EventBus;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -119,7 +117,7 @@ public class EmojiGridFragment extends Fragment {
         itemView.setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(final View v) {
-            EventBus.getDefault().post(new ItemClickedEvent<Emoji>(emoji));
+            FlexInput.eventManager.postOnItemClicked(emoji);
           }
         });
       }

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.java
@@ -17,13 +17,9 @@ import com.lytefast.flexinput.R;
 import com.lytefast.flexinput.R2;
 import com.lytefast.flexinput.adapters.FileListAdapter;
 import com.lytefast.flexinput.events.ClearAttachmentsEvent;
-import com.lytefast.flexinput.events.ItemClickedEvent;
 import com.lytefast.flexinput.managers.EventManager;
 import com.lytefast.flexinput.utils.FileUtils;
 import com.lytefast.flexinput.utils.SelectionCoordinator;
-
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
 
 import java.io.File;
 
@@ -104,13 +100,13 @@ public class FilesFragment extends Fragment {
   private final SelectionCoordinator<File> selectionCoordinator = new SelectionCoordinator<File>() {
     @Override
     public void onItemSelected(final File item) {
-      EventBus.getDefault().post(new ItemClickedEvent<>(FileUtils.toAttachment(item)));
+      FlexInput.eventManager.postOnItemClicked(FileUtils.toAttachment(item));
       Log.d(getClass().getCanonicalName(), "Select: " + item.getPath());
     }
 
     @Override
     public void onItemUnselected(final File item) {
-      EventBus.getDefault().post(new ItemClickedEvent<>(FileUtils.toAttachment(item)));
+      FlexInput.eventManager.postOnItemClicked(FileUtils.toAttachment(item));
       Log.d(getClass().getCanonicalName(), "Remove: " + item.getPath());
     }
   };

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
@@ -14,14 +14,9 @@ import com.lytefast.flexinput.R;
 import com.lytefast.flexinput.R2;
 import com.lytefast.flexinput.adapters.PhotoCursorAdapter;
 import com.lytefast.flexinput.events.ClearAttachmentsEvent;
-import com.lytefast.flexinput.events.ItemClickedEvent;
 import com.lytefast.flexinput.managers.EventManager;
-import com.lytefast.flexinput.managers.EventRxJavaManager;
 import com.lytefast.flexinput.model.Photo;
 import com.lytefast.flexinput.utils.SelectionCoordinator;
-
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -95,13 +90,13 @@ public class PhotosFragment extends Fragment {
   private final SelectionCoordinator<Photo> selectionCoordinator = new SelectionCoordinator<Photo>() {
     @Override
     public void onItemSelected(final Photo item) {
-      EventBus.getDefault().post(new ItemClickedEvent<>(item));
+      FlexInput.eventManager.postOnItemClicked(item);
       Log.d(getClass().getCanonicalName(), "Select[" + item.id + "]: " + item.displayName);
     }
 
     @Override
     public void onItemUnselected(final Photo item) {
-      EventBus.getDefault().post(new ItemClickedEvent<>(item));
+      FlexInput.eventManager.postOnItemClicked(item);
       Log.d(getClass().getCanonicalName(), "Remove[" + item.id + "]: " + item.displayName);
     }
   };

--- a/flexinput/src/main/java/com/lytefast/flexinput/managers/EventManager.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/managers/EventManager.java
@@ -15,7 +15,7 @@ public interface EventManager {
 
   <T> Bus<T> register(Object target, Class<T> clazz);
 
-  void postOnItemClicked(Attachment item);
+  <T> void postOnItemClicked(T item);
   void postOnClearAttachments();
 
   interface Bus<T> {


### PR DESCRIPTION
Use `EventManager` interface to abstract event bus system, and allow the user to choose their own implementation through plugins.

This seems like overkill for just a few events. Another solution might be to just manage a collection of listeners ourselves.