### PR TITLE
Update external open FAB to be transparent in the overlay area w/ a larger hit area.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
     <!--</style>-->
 
 
-    <style name="FlexInput.AddContent.FloatingActionButton" parent="FlexInput.AddContent.Base.FloatingActionButton">
+    <style name="FlexInput.AddContent.Button.Send" parent="FlexInput.AddContent.Button.Base.Send">
         <item name="backgroundTint">#38F</item>
     </style>
 

--- a/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
+++ b/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
@@ -35,13 +35,13 @@
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/action_btn"
-        style="@style/FlexInput.AddContent.FloatingActionButton"
+        style="@style/FlexInput.AddContent.Button.Send"
         app:layout_anchor="@id/content_pager"
         android:visibility="gone"/>
 
     <ImageView
         android:id="@+id/launch_btn"
-        style="@style/FlexInput.AddContent.Base.Button"
+        style="@style/FlexInput.AddContent.Button.Launcher"
         app:layout_anchor="@id/content_pager"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
+++ b/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
@@ -41,7 +41,7 @@
 
     <ImageView
         android:id="@+id/launch_btn"
-        style="@style/FlexInput.AddContent.FloatingActionButton.Launcher"
+        style="@style/FlexInput.AddContent.Base.Button"
         app:layout_anchor="@id/content_pager"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
+++ b/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
@@ -16,8 +16,9 @@
         android:layout_height="@dimen/default_keyboard_height"
         android:layout_gravity="bottom"/>
 
-    <FrameLayout style="@style/FlexInput.AddContent.Container.TabLayout"
-                 android:background="@android:color/transparent">
+    <FrameLayout
+        style="@style/FlexInput.AddContent.Container.TabLayout"
+        android:background="@android:color/transparent">
         <android.support.design.widget.TabLayout
             android:id="@+id/content_tabs"
             style="@style/FlexInput.AddContent.TabLayout"
@@ -34,22 +35,13 @@
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/action_btn"
+        android:visibility="gone"
         style="@style/FlexInput.AddContent.FloatingActionButton"
         app:layout_anchor="@id/content_pager"/>
 
-    <Space
-        android:id="@+id/fab_spacer"
-        android:layout_width="wrap_content"
-        android:layout_height="4dp"
-        android:layout_gravity="top|end|right"
-        app:layout_anchorGravity="top|end|right"
-        app:layout_anchor="@id/action_btn"/>
-
-    <android.support.design.widget.FloatingActionButton
+    <ImageView
         android:id="@+id/launch_btn"
         style="@style/FlexInput.AddContent.FloatingActionButton.Launcher"
-        android:layout_gravity="top|end|right"
-        app:layout_anchorGravity="top|end|right"
-        app:layout_anchor="@id/fab_spacer"/>
+        app:layout_anchor="@id/content_pager"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
+++ b/flexinput/src/main/res/layout/dialog_add_content_pager_with_fab.xml
@@ -35,9 +35,9 @@
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/action_btn"
-        android:visibility="gone"
         style="@style/FlexInput.AddContent.FloatingActionButton"
-        app:layout_anchor="@id/content_pager"/>
+        app:layout_anchor="@id/content_pager"
+        android:visibility="gone"/>
 
     <ImageView
         android:id="@+id/launch_btn"

--- a/flexinput/src/main/res/values/styles.xml
+++ b/flexinput/src/main/res/values/styles.xml
@@ -144,8 +144,11 @@
 
     <style name="FlexInput.AddContent.FloatingActionButton.Launcher" parent="FlexInput.AddContent.Base.FloatingActionButton">
         <item name="android:src">@drawable/ic_launch_24dp</item>
+        <item name="android:padding">16dp</item>
         <item name="fabSize">mini</item>
-        <item name="backgroundTint">@android:color/darker_gray</item>
+        <item name="android:layout_gravity">top|start|left</item>
+        <item name="layout_anchorGravity">top|start|left</item>
+        <item name="backgroundTint">@android:color/transparent</item>
     </style>
 
     <style name="FlexInput.Input.Button.Camera.Capture" parent="FlexInput.Input.Button">

--- a/flexinput/src/main/res/values/styles.xml
+++ b/flexinput/src/main/res/values/styles.xml
@@ -120,14 +120,28 @@
         <item name="android:clipToPadding">false</item>
     </style>
 
-    <style name="FlexInput.AddContent.Base.Button" parent="FlexInput.AddContent.Base.FloatingActionButton">
-        <item name="android:src">@drawable/ic_launch_24dp</item>
-        <item name="android:padding">16dp</item>
-        <item name="android:layout_gravity">top|start|left</item>
-        <item name="layout_anchorGravity">top|start|left</item>
-        <item name="backgroundTint">@android:color/transparent</item>
+    <style name="FlexInput.AddContent.Button" parent="FlexInput.AddContent">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:elevation" tools:targetApi="lollipop">8dp</item>
+        <item name="android:tint">@android:color/white</item>
+        <item name="android:tintMode" tools:targetApi="lollipop">src_atop</item>
     </style>
 
+    <style name="FlexInput.AddContent.Button.Base.Send" parent="FlexInput.AddContent.Button">
+        <item name="android:src">@drawable/ic_send_24dp</item>
+        <item name="android:layout_marginRight">16dp</item>
+        <item name="layout_anchorGravity">top|right|end</item>
+    </style>
+    <style name="FlexInput.AddContent.Button.Send" parent="FlexInput.AddContent.Button.Base.Send" />
+
+    <style name="FlexInput.AddContent.Button.Launcher">
+        <item name="android:padding">16dp</item>
+        <item name="android:src">@drawable/ic_launch_24dp</item>
+        <item name="android:layout_gravity">top|start|left</item>
+        <item name="layout_anchorGravity">top|start|left</item>
+        <item name="android:background">?selectableItemBackgroundBorderless</item>
+    </style>
     <style name="FlexInput.AddContent.Page" parent="FlexInput.AddContent.Base.Page"/>
 
     <style name="FlexInput.AddContent.Permissions" parent="FlexInput.AddContent">
@@ -137,19 +151,6 @@
         <item name="android:layout_marginLeft">8dp</item>
         <item name="android:layout_marginRight">8dp</item>
     </style>
-
-    <!-- Provided to allow simple overrides -->
-    <style name="FlexInput.AddContent.Base.FloatingActionButton" parent="FlexInput.AddContent">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:src">@drawable/ic_send_24dp</item>
-        <item name="android:elevation" tools:targetApi="lollipop">8dp</item>
-        <item name="layout_anchorGravity">top|right|end</item>
-        <item name="android:tint">@android:color/white</item>
-        <item name="android:tintMode" tools:targetApi="lollipop">src_atop</item>
-        <item name="android:layout_marginRight">16dp</item>
-    </style>
-    <style name="FlexInput.AddContent.FloatingActionButton" parent="FlexInput.AddContent.Base.FloatingActionButton"/>
 
     <style name="FlexInput.Input.Button.Camera.Capture" parent="FlexInput.Input.Button">
         <item name="android:layout_alignParentBottom">true</item>

--- a/flexinput/src/main/res/values/styles.xml
+++ b/flexinput/src/main/res/values/styles.xml
@@ -145,7 +145,6 @@
     <style name="FlexInput.AddContent.FloatingActionButton.Launcher" parent="FlexInput.AddContent.Base.FloatingActionButton">
         <item name="android:src">@drawable/ic_launch_24dp</item>
         <item name="android:padding">16dp</item>
-        <item name="fabSize">mini</item>
         <item name="android:layout_gravity">top|start|left</item>
         <item name="layout_anchorGravity">top|start|left</item>
         <item name="backgroundTint">@android:color/transparent</item>

--- a/flexinput/src/main/res/values/styles.xml
+++ b/flexinput/src/main/res/values/styles.xml
@@ -119,6 +119,15 @@
         <item name="android:paddingBottom">@dimen/add_content_viewpager_bottom_margin</item>
         <item name="android:clipToPadding">false</item>
     </style>
+
+    <style name="FlexInput.AddContent.Base.Button" parent="FlexInput.AddContent.Base.FloatingActionButton">
+        <item name="android:src">@drawable/ic_launch_24dp</item>
+        <item name="android:padding">16dp</item>
+        <item name="android:layout_gravity">top|start|left</item>
+        <item name="layout_anchorGravity">top|start|left</item>
+        <item name="backgroundTint">@android:color/transparent</item>
+    </style>
+
     <style name="FlexInput.AddContent.Page" parent="FlexInput.AddContent.Base.Page"/>
 
     <style name="FlexInput.AddContent.Permissions" parent="FlexInput.AddContent">
@@ -141,14 +150,6 @@
         <item name="android:layout_marginRight">16dp</item>
     </style>
     <style name="FlexInput.AddContent.FloatingActionButton" parent="FlexInput.AddContent.Base.FloatingActionButton"/>
-
-    <style name="FlexInput.AddContent.FloatingActionButton.Launcher" parent="FlexInput.AddContent.Base.FloatingActionButton">
-        <item name="android:src">@drawable/ic_launch_24dp</item>
-        <item name="android:padding">16dp</item>
-        <item name="android:layout_gravity">top|start|left</item>
-        <item name="layout_anchorGravity">top|start|left</item>
-        <item name="backgroundTint">@android:color/transparent</item>
-    </style>
 
     <style name="FlexInput.Input.Button.Camera.Capture" parent="FlexInput.Input.Button">
         <item name="android:layout_alignParentBottom">true</item>


### PR DESCRIPTION
Migrated the UI action which improves the hit area via padding and avoids the initial odd animations that come with trying to stack the actions on top of each other. 

![screen shot 2017-03-02 at 1 11 26 pm](https://cloud.githubusercontent.com/assets/658964/23527389/927c375a-ff4a-11e6-8988-7d17760abf3f.png)
