### PR TITLE
UX: make sure keyboard shows when add content dialog is closed

### DIFF
--- a/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
+++ b/app/src/main/java/com/lytefast/flexinput/sampleapp/MainFragment.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.AppCompatEditText;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
@@ -13,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
 
 import com.lytefast.flexinput.InputListener;
 import com.lytefast.flexinput.adapters.AttachmentPreviewAdapter;
@@ -81,18 +81,11 @@ public class MainFragment extends Fragment {
         .setFileManager(new SimpleFileManager("com.lytefast.flexinput.fileprovider", "FlexInput"))
         .setKeyboardManager(new KeyboardManager() {
           @Override
-          public void requestDisplay() {
-            FragmentActivity activity = getActivity();
-            if (activity == null) {
+          public void requestDisplay(final EditText textEt) {
+            if (textEt == null) {
               return;
             }
-            activity.runOnUiThread(new Runnable() {
-              @Override
-              public void run() {
-                flexInput.requestFocus();
-                imm.showSoftInput(flexInput.getView(), InputMethodManager.SHOW_IMPLICIT);
-              }
-            });
+            imm.showSoftInput(textEt, InputMethodManager.SHOW_IMPLICIT);
           }
 
           @Override

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FlexInputFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FlexInputFragment.java
@@ -13,7 +13,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.AppCompatEditText;
 import android.support.v7.widget.AppCompatImageButton;
@@ -290,6 +289,7 @@ public class FlexInputFragment extends Fragment
    */
   public FlexInputFragment setEditTextComponent(final AppCompatEditText customEditText) {
     customEditText.setId(R.id.text_input);
+    customEditText.setFocusable(true);
     customEditText.setFocusableInTouchMode(true);
     final Editable prevText = textEt.getText();
 
@@ -337,14 +337,15 @@ public class FlexInputFragment extends Fragment
   //endregion
 
   public void requestFocus() {
-    FragmentActivity activity = getActivity();
-    if (activity == null) {
+    textEt.requestFocus();
+    if (emojiContainer.getVisibility() == View.VISIBLE) {
       return;
     }
-    activity.runOnUiThread(new Runnable() {
+
+    textEt.post(new Runnable() {
       @Override
       public void run() {
-        textEt.requestFocus();
+        keyboardManager.requestDisplay(textEt);
       }
     });
   }
@@ -391,7 +392,7 @@ public class FlexInputFragment extends Fragment
   public void onEmojiToggle() {
     if (emojiContainer.getVisibility() == View.VISIBLE) {
       hideEmojiTray();
-      keyboardManager.requestDisplay();
+      keyboardManager.requestDisplay(textEt);
     } else {
       showEmojiTray();
     }
@@ -416,7 +417,7 @@ public class FlexInputFragment extends Fragment
         if (!FlexInputFragment.this.isAdded() || FlexInputFragment.this.isHidden()) {
           return;  // Nothing to do
         }
-        keyboardManager.requestDisplay();
+        requestFocus();
         updateAttachmentPreviewContainer();
       }
     });

--- a/flexinput/src/main/java/com/lytefast/flexinput/managers/KeyboardManager.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/managers/KeyboardManager.java
@@ -1,11 +1,14 @@
 package com.lytefast.flexinput.managers;
 
+import android.widget.EditText;
+
+
 /**
  * Defines interactions with the on screen keyboard.
  *
  * @author Sam Shih
  */
 public interface KeyboardManager {
-  void requestDisplay();
+  void requestDisplay(final EditText editText);
   void requestHide();
 }


### PR DESCRIPTION
This change ensures that the keyboard is always shown on `AddContentDialogFragment` dismiss.
The secret sauce here is that the `InputMethodManager` actually needs to have a proper input field for it to show the keyboard. We also need to ensure that the call is done on the UI thread.