### PR TITLE
Clear target Fragment on `saveInstanceState` to avoid "Fragment no longer exists" crash.

### DIFF
--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
@@ -129,13 +129,6 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
   }
 
   @Override
-  public void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-
-    setTargetFragment(null, 0 /* result code unused */);
-  }
-
-  @Override
   public void onResume() {
     super.onResume();
     actionButton.post(new Runnable() {
@@ -144,6 +137,12 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
         updateActionButton();
       }
     });
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    setTargetFragment(null, 0 /* result code unused */);
   }
 
   @Override

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
@@ -129,6 +129,13 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
   }
 
   @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+
+    setTargetFragment(null, 0 /* result code unused */);
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
     actionButton.post(new Runnable() {


### PR DESCRIPTION
This PR should address the following crash which can be exhibited upon device rotation while the picker is open (but I suspect only if the picker itself is a sub-fragment since this is not exhibited on the sample app).

Suggested fix was discovered in: https://issuetracker.google.com/issues/36969568