### PR TITLE
Handle fragment transaction on next UI tick after user interaction.

### DIFF
--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FlexInputFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FlexInputFragment.java
@@ -7,6 +7,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
@@ -425,6 +426,15 @@ public class FlexInputFragment extends Fragment
     hideEmojiTray();
     keyboardManager.requestHide();  // Make sure the keyboard is hidden
 
+    new Handler().post(new Runnable() {
+      @Override
+      public void run() {
+        attachContentDialogFragment();
+      }
+    });
+  }
+
+  private void attachContentDialogFragment() {
     FragmentTransaction ft = getChildFragmentManager().beginTransaction();
     final AddContentDialogFragment dialogFrag = new AddContentDialogFragment();
     dialogFrag.show(ft, ADD_CONTENT_FRAG_TAG);


### PR DESCRIPTION
This should fix a hard crash related to Fragment transactions.

More info here: https://trello.com/c/4JuMsHbs

I don't know if this for sure fixes the bug as I was never able to reproduce it but this seems like a safe change to make since the transaction is being triggered by user input.

Open to other suggestions though.