### PR TITLE
Avoid using get/set targetFragment and use `getParentFragment()` directly.

### DIFF
--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/AddContentDialogFragment.java
@@ -109,7 +109,6 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
     Fragment parentFragment = getParentFragment();
     if (parentFragment instanceof FlexInputFragment) {
       final FlexInputFragment flexInputFragment = (FlexInputFragment) parentFragment;
-      setTargetFragment(flexInputFragment, 0 /* result code unused */);
       initContentPages(
           new AddContentPagerAdapter(getChildFragmentManager(), flexInputFragment.getContentPages()));
 
@@ -137,12 +136,6 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
         updateActionButton();
       }
     });
-  }
-
-  @Override
-  public void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-    setTargetFragment(null, 0 /* result code unused */);
   }
 
   @Override
@@ -300,7 +293,7 @@ public class AddContentDialogFragment extends AppCompatDialogFragment {
 
     ClipData clipData = data.getClipData();
 
-    FlexInputCoordinator<Attachment> flexInputCoordinator = (FlexInputCoordinator<Attachment>) getTargetFragment();
+    FlexInputCoordinator<Attachment> flexInputCoordinator = (FlexInputCoordinator<Attachment>) getParentFragment();
     if (clipData == null) {
       Uri uri = data.getData();
       flexInputCoordinator.addExternalAttachment(toAttachment(uri));

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/CameraFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/CameraFragment.java
@@ -85,7 +85,8 @@ public class CameraFragment extends PermissionsFragment {
   @Nullable
   @Override
   public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
-    final Fragment targetFragment = getParentFragment().getTargetFragment();
+    Fragment targetFragment = getParentFragment();
+    targetFragment = targetFragment != null ? targetFragment.getParentFragment() : null;
     if (targetFragment instanceof FlexInputCoordinator) {
       this.flexInputCoordinator = (FlexInputCoordinator) targetFragment;
     }

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.java
@@ -56,7 +56,8 @@ public class FilesFragment extends PermissionsFragment {
                            Bundle savedInstanceState) {
     this.selectionCoordinator = new SelectionCoordinator<>();
 
-    final Fragment targetFragment = getParentFragment().getTargetFragment();
+    Fragment targetFragment = getParentFragment();
+    targetFragment = targetFragment != null ? targetFragment.getParentFragment() : null;
     if (targetFragment instanceof FlexInputCoordinator) {
       FlexInputCoordinator flexInputCoordinator = (FlexInputCoordinator) targetFragment;
 

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/PhotosFragment.java
@@ -52,7 +52,8 @@ public class PhotosFragment extends PermissionsFragment {
                            Bundle savedInstanceState) {
     this.selectionCoordinator = new SelectionCoordinator<>();
 
-    final Fragment targetFragment = getParentFragment().getTargetFragment();
+    Fragment targetFragment = getParentFragment();
+    targetFragment = targetFragment != null ? targetFragment.getParentFragment() : null;
     if (targetFragment instanceof FlexInputCoordinator) {
       FlexInputCoordinator flexInputCoordinator = (FlexInputCoordinator) targetFragment;
 


### PR DESCRIPTION
It seems like using target fragments is not nessisary - some say it's not reccomended https://issuetracker.google.com/issues/36969568 - although there is a lot of conflicting information going around.

The picker still works without it however and it simplifies us having to manage the target fragment lifecycle.