### PR TITLE
Fix: FileAdapter comparison broke api contract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ buildscript {
 
         // Platform
         espressoCoreVersion = '3.0.1'
-        kotlin_version = '1.2.50'
+        kotlin_version = '1.2.60'
         supportLibraryVersion = '27.1.1'
         supportLibraryConstraintVersion = '1.1.2'
         junitVersion = '4.12'
 
         // 3rd party libs
-        frescoVersion = '1.9.0'
+        frescoVersion = '1.10.0'
     }
 
     repositories {
@@ -25,7 +25,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
@@ -195,14 +195,10 @@ class FileListAdapter(private val contentResolver: ContentResolver,
     override fun doInBackground(vararg rootFiles: File): List<Attachment<File>> {
       val files = flattenFileList(rootFiles[0])
 
-      Collections.sort(files) { f1, f2 ->
-        // Sort by newest first
-        val timeCompare = f2.lastModified.compareTo(f1.lastModified)
-        when (timeCompare) {
-          0 -> f2.uri.compareTo(f1.uri)
-          else -> timeCompare
-        }
-      }
+      files.sortWith(
+          compareByDescending<Attachment<File>> { it.lastModified }
+              .then(compareBy { it.uri })
+      )
       return files
     }
 
@@ -211,7 +207,7 @@ class FileListAdapter(private val contentResolver: ContentResolver,
       this.adapter.notifyDataSetChanged()
     }
 
-    private fun flattenFileList(parentDir: File): List<Attachment<File>> {
+    private fun flattenFileList(parentDir: File): MutableList<Attachment<File>> {
       fun File.getFileList() = listFiles()?.asSequence() ?: emptySequence()
 
       val flattenedFileList = ArrayList<Attachment<File>>()


### PR DESCRIPTION
```
Comparison method violates its general contract!
com.lytefast.flexinput.adapters.FileListAdapter$FileLoaderTask.doInBackground
```
https://console.firebase.google.com/project/adept-ethos-91518/crashlytics/app/android:com.discord/issues/5adc1ffe36c7b23527a85a22?time=last-seven-days&sessionId=5B6E0100021E00017ABB81890D6B46C0_DNE_0_v2