### PR TITLE
Fix for Android 10 Files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning">
 
         <provider

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
@@ -125,49 +125,48 @@ class FileListAdapter(private val contentResolver: ContentResolver,
           bindThumbIvWithImage(file)
         }
         mimeType.startsWith("audio") -> {
-          //TODO audio icon
+          typeIv.setImageResource(R.drawable.ic_audio_24dp)
+          typeIv.visibility = View.VISIBLE
           bindThumbIvWithImage(file)
         }
       }
     }
 
     private fun bindThumbIvWithImage(file: File) {
-      if (!BuildUtils.isAndroidQ()) {
-        contentResolver.query(
-            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-            arrayOf(MediaStore.Images.Media._ID, MediaStore.Images.Media.MINI_THUMB_MAGIC),
-            "${MediaStore.Images.Media.DATA}=?",
-            arrayOf(file.path), null/* sortOrder */)
-            ?.use { cursor ->
-              if (!cursor.moveToFirst()) return
-              val imageId = cursor.getLong(0)
-              val thumbMagic = cursor.getLong(1)
+      contentResolver.query(
+          MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+          arrayOf(MediaStore.Images.Media._ID, MediaStore.Images.Media.MINI_THUMB_MAGIC),
+          "${MediaStore.Images.Media.DATA}=?",
+          arrayOf(file.path), null/* sortOrder */)
+          ?.use { cursor ->
+            if (!cursor.moveToFirst()) return
+            val imageId = cursor.getLong(0)
+            val thumbMagic = cursor.getLong(1)
 
-              if (thumbMagic == 0L) {
-                // Force thumbnail generation
-                val genThumb = MediaStore.Images.Thumbnails.getThumbnail(
-                    contentResolver, imageId, MediaStore.Images.Thumbnails.MINI_KIND, null)
-                genThumb?.recycle()
-              }
-
-              contentResolver.query(
-                  MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI,
-                  arrayOf(MediaStore.Images.Thumbnails._ID),
-                  "${MediaStore.Images.Thumbnails.IMAGE_ID}=?",
-                  arrayOf(java.lang.Long.toString(imageId)),
-                  null)
-                  ?.use { thumbnailCursor ->
-                    if (!thumbnailCursor.moveToFirst()) return
-                    val thumbId = thumbnailCursor.getString(0)
-
-                    thumbIv.controller = Fresco.newDraweeControllerBuilder()
-                        .setOldController(thumbIv.controller)
-                        .setUri(Uri.withAppendedPath(MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI, thumbId))
-                        .setTapToRetryEnabled(true)
-                        .build()
-                  }
+            if (thumbMagic == 0L) {
+              // Force thumbnail generation
+              val genThumb = MediaStore.Images.Thumbnails.getThumbnail(
+                  contentResolver, imageId, MediaStore.Images.Thumbnails.MINI_KIND, null)
+              genThumb?.recycle()
             }
-      }
+
+            contentResolver.query(
+                MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI,
+                arrayOf(MediaStore.Images.Thumbnails._ID),
+                "${MediaStore.Images.Thumbnails.IMAGE_ID}=?",
+                arrayOf(java.lang.Long.toString(imageId)),
+                null)
+                ?.use { thumbnailCursor ->
+                  if (!thumbnailCursor.moveToFirst()) return
+                  val thumbId = thumbnailCursor.getString(0)
+
+                  thumbIv.controller = Fresco.newDraweeControllerBuilder()
+                      .setOldController(thumbIv.controller)
+                      .setUri(Uri.withAppendedPath(MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI, thumbId))
+                      .setTapToRetryEnabled(true)
+                      .build()
+                }
+          }
     }
 
     fun setSelected(isSelected: Boolean, isAnimationRequested: Boolean) {

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
@@ -18,7 +18,6 @@ import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.view.SimpleDraweeView
 import com.lytefast.flexinput.R
 import com.lytefast.flexinput.model.Attachment
-import com.lytefast.flexinput.utils.BuildUtils
 import com.lytefast.flexinput.utils.FileUtils.getFileSize
 import com.lytefast.flexinput.utils.FileUtils.toAttachment
 import com.lytefast.flexinput.utils.SelectionCoordinator
@@ -39,12 +38,6 @@ class FileListAdapter(private val contentResolver: ContentResolver,
   private val selectionCoordinator: SelectionCoordinator<*, in Attachment<File>> =
       selectionCoordinator.bind(this)
   private var files: List<Attachment<File>> = listOf()
-
-  override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
-    super.onAttachedToRecyclerView(recyclerView)
-    shrinkAnim = AnimatorInflater.loadAnimator(recyclerView.context, R.animator.selection_shrink) as AnimatorSet
-    growAnim = AnimatorInflater.loadAnimator(recyclerView.context, R.animator.selection_grow) as AnimatorSet
-  }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
     val view = LayoutInflater.from(parent.context)
@@ -81,17 +74,27 @@ class FileListAdapter(private val contentResolver: ContentResolver,
 
     private var attachmentFile: Attachment<File>? = null
 
+    private val shrinkAnim: AnimatorSet
+    private val growAnim: AnimatorSet
+
     init {
       this.itemView.isClickable = true
       this.itemView.setOnClickListener {
         setSelected(selectionCoordinator.toggleItem(attachmentFile, adapterPosition), true)
       }
+
+      //region Perf: Load animations once
+      this.shrinkAnim = AnimatorInflater.loadAnimator(
+          itemView.context, R.animator.selection_shrink) as AnimatorSet
+      this.shrinkAnim.setTarget(thumbIv)
+
+      this.growAnim = AnimatorInflater.loadAnimator(
+          itemView.context, R.animator.selection_grow) as AnimatorSet
+      this.growAnim.setTarget(thumbIv)
+      //endregion
     }
 
     fun bind(fileAttachment: Attachment<File>) {
-      shrinkAnim?.setTarget(thumbIv)
-      growAnim?.setTarget(thumbIv)
-
       this.attachmentFile = fileAttachment
       setSelected(selectionCoordinator.isSelected(fileAttachment, adapterPosition), false)
 
@@ -238,10 +241,5 @@ class FileListAdapter(private val contentResolver: ContentResolver,
 
     private val Attachment<File>.lastModified
       get() = data?.lastModified() ?: 0
-  }
-
-  companion object {
-    private var shrinkAnim: AnimatorSet? = null
-    private var growAnim: AnimatorSet? = null
   }
 }

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/FileListAdapter.kt
@@ -34,7 +34,6 @@ class FileListAdapter(private val contentResolver: ContentResolver,
                       selectionCoordinator: SelectionCoordinator<*, Attachment<File>>)
   : RecyclerView.Adapter<FileListAdapter.ViewHolder>() {
 
-
   private val selectionCoordinator: SelectionCoordinator<*, in Attachment<File>> =
       selectionCoordinator.bind(this)
   private var files: List<Attachment<File>> = listOf()
@@ -67,6 +66,9 @@ class FileListAdapter(private val contentResolver: ContentResolver,
 
   @Suppress("MemberVisibilityCanBePrivate")
   open inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    private val shrinkAnim: AnimatorSet
+    private val growAnim: AnimatorSet
+
     protected var thumbIv: SimpleDraweeView = itemView.findViewById(R.id.thumb_iv)
     protected var typeIv: ImageView = itemView.findViewById(R.id.type_iv)
     protected var fileNameTv: TextView = itemView.findViewById(R.id.file_name_tv)
@@ -74,8 +76,6 @@ class FileListAdapter(private val contentResolver: ContentResolver,
 
     private var attachmentFile: Attachment<File>? = null
 
-    private val shrinkAnim: AnimatorSet
-    private val growAnim: AnimatorSet
 
     init {
       this.itemView.isClickable = true
@@ -183,9 +183,9 @@ class FileListAdapter(private val contentResolver: ContentResolver,
       }
 
       if (isSelected) {
-        if (thumbIv.scaleX == 1.0f) shrinkAnim?.let { scaleImage(it) }
+        if (thumbIv.scaleX == 1.0f) scaleImage(shrinkAnim)
       } else {
-        if (thumbIv.scaleX != 1.0f) growAnim?.let { scaleImage(it) }
+        if (thumbIv.scaleX != 1.0f) scaleImage(growAnim)
       }
     }
   }

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/PhotoCursorAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/PhotoCursorAdapter.kt
@@ -11,13 +11,12 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.Build
 import android.provider.MediaStore
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.facebook.drawee.drawable.FadeDrawable
 import com.facebook.drawee.drawable.ScalingUtils
@@ -25,9 +24,13 @@ import com.facebook.drawee.generic.RoundingParams
 import com.facebook.drawee.view.SimpleDraweeView
 import com.lytefast.flexinput.R
 import com.lytefast.flexinput.model.Photo
+import com.lytefast.flexinput.utils.BuildUtils
 import com.lytefast.flexinput.utils.SelectionCoordinator
-import kotlinx.coroutines.*
-import androidx.core.content.ContextCompat
+import com.lytefast.flexinput.utils.ThumbnailUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 
 /**
@@ -56,7 +59,6 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
     super.onAttachedToRecyclerView(recyclerView)
 
     emptyColorDrawable = ColorDrawable(recyclerView.context.themeColor(R.attr.flexInputDialogBackground))
-
     shrinkAnim = AnimatorInflater.loadAnimator(recyclerView.context, R.animator.selection_shrink) as AnimatorSet
     growAnim = AnimatorInflater.loadAnimator(recyclerView.context, R.animator.selection_grow) as AnimatorSet
 
@@ -155,14 +157,16 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
 
       this.photo = photo
 
-      if (isAndroidQ()) {
+      if (BuildUtils.isAndroidQ()) {
         clear()
 
         imageView.hierarchy.setPlaceholderImage(emptyColorDrawable, ScalingUtils.ScaleType.CENTER)
 
         // Ensure this executes on the main thread for UI interaction (as opposed to IO)
         loadThumbnailJob = GlobalScope.launch(context = Dispatchers.Main) {
-          thumbnailBitmap = getThumbnailAsync()
+          thumbnailBitmap = photo?.uri?.let { uri ->
+            ThumbnailUtils.getThumbnailQAsync(contentResolver, uri, thumbnailWidth, thumbnailHeight)
+          }
           thumbnailDrawable = BitmapDrawable(imageView.resources, thumbnailBitmap)
           val fadeDrawable = FadeDrawable(arrayOf(emptyColorDrawable, thumbnailDrawable))
 
@@ -207,17 +211,12 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
       selectionCoordinator.toggleItem(photo, adapterPosition)
     }
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    private suspend fun getThumbnailAsync() = withContext(Dispatchers.IO) {
-      photo?.getThumbnailQ(contentResolver, thumbnailWidth, thumbnailHeight)
-    }
-
     fun onViewRecycled() {
       clear()
     }
 
     private fun clear() {
-      if (isAndroidQ()) {
+      if (BuildUtils.isAndroidQ()) {
         loadThumbnailJob?.cancel()
 
         thumbnailDrawable?.bitmap?.recycle()
@@ -239,8 +238,6 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
 
     fun Context.dpToPixels(dipValue: Float) =
         TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dipValue, resources.displayMetrics)
-
-    fun isAndroidQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
     fun Context.themeColor(themeAttributeId: Int): Int {
       val outValue = TypedValue()

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.kt
@@ -3,12 +3,12 @@ package com.lytefast.flexinput.fragment
 import android.Manifest
 import android.os.Bundle
 import android.os.Environment
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.lytefast.flexinput.FlexInputCoordinator
 import com.lytefast.flexinput.R
 import com.lytefast.flexinput.adapters.EmptyListAdapter
@@ -97,9 +97,8 @@ open class FilesFragment : PermissionsFragment() {
     swipeRefreshLayout!!.isRefreshing = false
   }
 
-
   private fun requestPermissions() {
-    requestPermissions(object : PermissionsResultCallback {
+    requestPermissions(object : PermissionsFragment.PermissionsResultCallback {
       override fun granted() {
         context?.contentResolver?.let { contentResolver ->
           adapter = FileListAdapter(contentResolver, selectionCoordinator!!)

--- a/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/fragment/FilesFragment.kt
@@ -3,12 +3,12 @@ package com.lytefast.flexinput.fragment
 import android.Manifest
 import android.os.Bundle
 import android.os.Environment
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.lytefast.flexinput.FlexInputCoordinator
 import com.lytefast.flexinput.R
 import com.lytefast.flexinput.adapters.EmptyListAdapter
@@ -97,8 +97,9 @@ open class FilesFragment : PermissionsFragment() {
     swipeRefreshLayout!!.isRefreshing = false
   }
 
+
   private fun requestPermissions() {
-    requestPermissions(object : PermissionsFragment.PermissionsResultCallback {
+    requestPermissions(object : PermissionsResultCallback {
       override fun granted() {
         context?.contentResolver?.let { contentResolver ->
           adapter = FileListAdapter(contentResolver, selectionCoordinator!!)

--- a/flexinput/src/main/java/com/lytefast/flexinput/model/Photo.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/model/Photo.kt
@@ -2,16 +2,12 @@ package com.lytefast.flexinput.model
 
 import android.content.ContentResolver
 import android.content.ContentUris
-import android.graphics.Bitmap
 import android.net.Uri
 import android.os.AsyncTask
-import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import android.provider.MediaStore
 import android.util.Log
-import android.util.Size
-import androidx.annotation.RequiresApi
 
 
 /**
@@ -25,16 +21,6 @@ class Photo : Attachment<String> {
       : super(id, uri, displayName, photoDataLocation)
 
   constructor(parcelIn: Parcel) : super(parcelIn)
-
-  @RequiresApi(Build.VERSION_CODES.Q)
-  fun getThumbnailQ(contentResolver: ContentResolver, width: Int, height: Int): Bitmap? {
-    return try {
-      contentResolver.loadThumbnail(uri, Size(width, height), null)
-    } catch (e: java.lang.Exception) {
-      Log.e("Thumbnail", "Thumbnail Failed to load $e")
-      null
-    }
-  }
 
   fun getThumbnailUri(contentResolver: ContentResolver): Uri? {
     val cursor = contentResolver.query(

--- a/flexinput/src/main/java/com/lytefast/flexinput/utils/BuildUtils.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/utils/BuildUtils.kt
@@ -2,6 +2,6 @@ package com.lytefast.flexinput.utils
 
 import android.os.Build
 
-object BuildUtils{
+object BuildUtils {
   fun isAndroidQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 }

--- a/flexinput/src/main/java/com/lytefast/flexinput/utils/BuildUtils.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/utils/BuildUtils.kt
@@ -1,0 +1,7 @@
+package com.lytefast.flexinput.utils
+
+import android.os.Build
+
+object BuildUtils{
+  fun isAndroidQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+}

--- a/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
@@ -1,0 +1,25 @@
+package com.lytefast.flexinput.utils
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import android.util.Size
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+object ThumbnailUtils {
+
+  @RequiresApi(Build.VERSION_CODES.Q)
+  suspend fun getThumbnailQAsync(contentResolver: ContentResolver, uri: Uri, width: Int, height: Int): Bitmap? = withContext(Dispatchers.IO) {
+    try {
+      Log.d("Thumbnail", "Loading thumbnail $uri")
+      contentResolver.loadThumbnail(uri, Size(width, height), null)
+    } catch (e: Exception) {
+      Log.e("Thumbnail", "Thumbnail Failed to load $e")
+      null
+    }
+  }
+}

--- a/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.withContext
 object ThumbnailUtils {
 
   @RequiresApi(Build.VERSION_CODES.Q)
-  suspend fun getThumbnailQAsync(contentResolver: ContentResolver, uri: Uri, width: Int, height: Int): Bitmap? = withContext(Dispatchers.IO) {
+  suspend fun getThumbnailQ(contentResolver: ContentResolver, uri: Uri, width: Int, height: Int): Bitmap? = withContext(Dispatchers.IO) {
     try {
       Log.d("Thumbnail", "Loading thumbnail $uri")
       contentResolver.loadThumbnail(uri, Size(width, height), null)

--- a/flexinput/src/main/res/drawable/ic_audio_24dp.xml
+++ b/flexinput/src/main/res/drawable/ic_audio_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?flexInputIconColor"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4V7h4V3h-6z"/>
+</vector>


### PR DESCRIPTION
Fixes displaying files in FlexInput for Android 10. Note this is a short term fix that relies on a legacy flag to be enabled in the implementing app. In the future we will need to defer to the system picker via an Intent.