### PR TITLE
Fix Discord URL on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Android EditText wrapper to support text/emoji/camera/media input.
 - file/attachment preview
 - multi-file support
 
-Used in the [Discord](www.discordapp.com) android app!
+Used in the [Discord](https://discordapp.com) android app!
 
 <img src="/images/keyboard.png" width="240">
   


### PR DESCRIPTION
Currently, if the link is clicked, it redirects to https://github.com/lytefast/flex-input/blob/master/www.discordapp.com which is probably not where you want to redirect.