### PR TITLE
Attempt to fix bug with coroutines

### DIFF
--- a/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/utils/ThumbnailUtils.kt
@@ -4,6 +4,7 @@ import android.content.ContentResolver
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
+import android.os.CancellationSignal
 import android.util.Log
 import android.util.Size
 import androidx.annotation.RequiresApi
@@ -13,10 +14,10 @@ import kotlinx.coroutines.withContext
 object ThumbnailUtils {
 
   @RequiresApi(Build.VERSION_CODES.Q)
-  suspend fun getThumbnailQ(contentResolver: ContentResolver, uri: Uri, width: Int, height: Int): Bitmap? = withContext(Dispatchers.IO) {
+  suspend fun getThumbnailQ(contentResolver: ContentResolver, uri: Uri, width: Int, height: Int, cancelSignal: CancellationSignal? = null): Bitmap? = withContext(Dispatchers.IO) {
     try {
       Log.d("Thumbnail", "Loading thumbnail $uri")
-      contentResolver.loadThumbnail(uri, Size(width, height), null)
+      contentResolver.loadThumbnail(uri, Size(width, height), cancelSignal)
     } catch (e: Exception) {
       Log.e("Thumbnail", "Thumbnail Failed to load $e")
       null


### PR DESCRIPTION
This is an attempt to fix a class cast exception on line 173 of `PhotoCursorAdapter`.

* Adds cancellation signal functionality, so `cancel()` will actually stop the thumbnail from being retrieved.

* Removes the let insides the `launch()` closure.