### PR TITLE
force proguard 6.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,9 @@ buildscript {
 
     configurations.all {
         resolutionStrategy {
-            // Want to force this proguard release.
+            // Want to force this proguard release because it contains bugfixes related to
+            // coroutines. Feel free to remove this code when the gradle-bundled is 6.2.0+.
+            // For more information: https://github.com/lytefast/flex-input/pull/50
             force 'net.sf.proguard:proguard-gradle:6.2.0'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,18 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            // Want to force this proguard release.
+            force 'net.sf.proguard:proguard-gradle:6.2.0'
+        }
     }
 }
 


### PR DESCRIPTION
Some clients of this library have been experiencing this issue related to Kotlin coroutines: https://github.com/Kotlin/kotlinx.coroutines/issues/1035

According to that thread, version 6.2.0 of proguard fixes the issue: https://github.com/Kotlin/kotlinx.coroutines/issues/1035#issuecomment-539978415

This PR forces proguard 6.2.0. We can remove this code once the proguard version bundled with the gradle plugin has been updated.