### PR TITLE
Fix: AndroidQ photo check recycled state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         // Latest versions here: https://developer.android.com/jetpack/androidx/migrate
         ext.androidxVersion = '1.1.0'
         ext.androidxCoreVersion = '1.1.0'
-        ext.androidxRecyclerView = '1.1.0-beta04'
+        ext.androidxRecyclerView = '1.1.0-rc01'
         ext.appCompatVersion = '1.1.0'
         ext.constraintLayoutVersion = '1.1.3'
         ext.materialVersion = '1.0.0'

--- a/flexinput/src/main/java/com/lytefast/flexinput/adapters/PhotoCursorAdapter.kt
+++ b/flexinput/src/main/java/com/lytefast/flexinput/adapters/PhotoCursorAdapter.kt
@@ -166,6 +166,10 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
     fun bind(photo: Photo?) {
       this.photo = photo
 
+      if (photo != null) {
+        setSelected(selectionCoordinator.isSelected(photo, adapterPosition), false)
+      }
+
       if (BuildUtils.isAndroidQ()) {
         clear()
 
@@ -192,11 +196,7 @@ class PhotoCursorAdapter(private val contentResolver: ContentResolver,
           holderFadeDrawable = fadeDrawable
         }
       } else {
-        val thumbnailUri = photo?.let {
-          setSelected(selectionCoordinator.isSelected(photo, adapterPosition), false)
-          it.getThumbnailUri(contentResolver)
-        }
-
+        val thumbnailUri = photo?.getThumbnailUri(contentResolver)
         imageView.setImageURI(thumbnailUri, imageView.context)
       }
     }


### PR DESCRIPTION
On Q: this caused recycled views to not reset or remember checked state.